### PR TITLE
Use SMPEG config tools

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,13 +3,15 @@ all: alien
 CC=gcc
 SDL_CFLAGS = `sdl-config --cflags`
 SDL_LIBS = `sdl-config --libs`
-CFLAGS=-ggdb -DENABLE_DEBUG -Wall $(SDL_CFLAGS)
+SMPEG_CFLAGS = `smpeg-config --cflags`
+SMPEG_LIBS = `smpeg-config --libs`
+CFLAGS=-ggdb -DENABLE_DEBUG -Wall $(SDL_CFLAGS) $(SMPEG_CFLAGS)
 OBJS=\
 	client.o common.o vm.o      sprites.o decode.o   animation.o   \
 	rooms.o  render.o main.o    music.o   debug.o    lzss.o        \
 	sound.o  screen.o scale2x.o scale3x.o game2bin.o cd_iso.o
 
-LIBS=$(SDL_LIBS) -lSDLmain -lsmpeg -lSDL_mixer
+LIBS=$(SDL_LIBS) $(SMPEG_LIBS) -lSDL_mixer
 
 alien: $(OBJS)
 	$(CC) -o $@ $(OBJS) $(LIBS)


### PR DESCRIPTION
This fixed the build for me on @openSUSE. Using the tools might make this more distribution agnostic. I am not sure about the removal of `-lSDLmain` but it fixed the compilation.